### PR TITLE
Notifs: clear badge when navigating to notifs tab

### DIFF
--- a/mobile/js/Main.js
+++ b/mobile/js/Main.js
@@ -229,7 +229,8 @@ if (Platform.OS === 'android') {
 
   const handlePushNotification = ({ data, clicked }) => {
     if (data?.numUnseenNotifications && !clicked) {
-      PushNotifications.setBadgeCount(data.numUnseenNotifications);
+      // Update badge so we don't have to wait on maybeFetchNotificationsAsync() to do it
+      Session.setNotifBadge(data.numUnseenNotifications);
     }
     Session.maybeFetchNotificationsAsync();
   };

--- a/mobile/js/Navigation.js
+++ b/mobile/js/Navigation.js
@@ -4,7 +4,7 @@ import { createNativeStackNavigator } from 'react-native-screens/native-stack';
 import { NavigationContainer, DefaultTheme } from '@react-navigation/native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 
-import { useSession, maybeFetchNotificationsAsync } from './Session';
+import { useSession, maybeFetchNotificationsAsync, setNotifBadge } from './Session';
 
 import { LoginScreen, CreateAccountScreen, ForgotPasswordScreen } from './AuthScreens';
 import { CreateScreen } from './create/CreateScreen';
@@ -241,7 +241,8 @@ export const RootNavigator = () => {
   // fetch notifications when a notif arrives while we're running
   const handlePushNotification = React.useCallback(({ data, clicked }) => {
     if (data?.numUnseenNotifications && !clicked) {
-      PushNotifications.setBadgeCount(data.numUnseenNotifications);
+      // Update badge so we don't have to wait on maybeFetchNotificationsAsync() to do it
+      setNotifBadge(data.numUnseenNotifications);
     }
     if (clicked && rootNavRef.current) {
       // pass the `screen` param to ensure we pop to the top of the stack

--- a/mobile/js/PushNotifications.js
+++ b/mobile/js/PushNotifications.js
@@ -102,6 +102,7 @@ export const addTokenListener = (listener) => {
   });
 };
 
+// Set the app badge count on both platforms AND the in-app notifs tab badge on Android
 export const setBadgeCount = async (count) => {
   if (Platform.OS === 'ios') {
     return NativeModules.GhostPushNotifications.setBadgeCount(count);

--- a/mobile/js/Session.js
+++ b/mobile/js/Session.js
@@ -718,6 +718,16 @@ const _sendMarkNotificationsRead = debounce(
   100
 );
 
+export const setNotifBadge = (count) => {
+  // Sets app badge on iOS + Android and in-app tab badge on Android
+  PushNotifications.setBadgeCount(count);
+
+  // Sets in-app tab badge on iOS
+  EventEmitter.sendEvent('notifications', {
+    notificationsBadgeCount: count,
+  });
+};
+
 const NOTIF_FETCH_THRESHOLD_MS = 10 * 60 * 1000;
 let notifLastFetchTime;
 
@@ -770,22 +780,10 @@ export const maybeFetchNotificationsAsync = async (force = true) => {
     ? notifications.reduce((accum, n) => accum + (n.status === 'unseen'), 0)
     : 0;
   PushNotifications.setNewFollowingDecks(newFollowingDecks);
-
-  // This replicates the behavior of setNotifBadge()
-  PushNotifications.setBadgeCount(notificationsBadgeCount);
   EventEmitter.sendEvent('notifications', {
     newFollowingDecks,
     notifications,
-    notificationsBadgeCount,
   });
-};
 
-export const setNotifBadge = (count) => {
-  // Sets app badge on iOS + Android and in-app tab badge on Android
-  PushNotifications.setBadgeCount(count);
-
-  // Sets in-app tab badge on iOS
-  EventEmitter.sendEvent('notifications', {
-    notificationsBadgeCount: count,
-  });
+  setNotifBadge(notificationsBadgeCount);
 };

--- a/mobile/js/Session.js
+++ b/mobile/js/Session.js
@@ -223,15 +223,9 @@ export class Provider extends React.Component {
 
         return n;
       });
-      const notificationsBadgeCount = notifications.reduce(
-        (accum, n) => accum + (n.status === 'unseen'),
-        0
-      );
-      PushNotifications.setBadgeCount(notificationsBadgeCount);
       return {
         ...state,
         notifications,
-        notificationsBadgeCount,
       };
     });
   };
@@ -775,11 +769,23 @@ export const maybeFetchNotificationsAsync = async (force = true) => {
   const notificationsBadgeCount = notifications
     ? notifications.reduce((accum, n) => accum + (n.status === 'unseen'), 0)
     : 0;
-  PushNotifications.setBadgeCount(notificationsBadgeCount);
   PushNotifications.setNewFollowingDecks(newFollowingDecks);
+
+  // This replicates the behavior of setNotifBadge()
+  PushNotifications.setBadgeCount(notificationsBadgeCount);
   EventEmitter.sendEvent('notifications', {
     newFollowingDecks,
     notifications,
     notificationsBadgeCount,
+  });
+};
+
+export const setNotifBadge = (count) => {
+  // Sets app badge on iOS + Android and in-app tab badge on Android
+  PushNotifications.setBadgeCount(count);
+
+  // Sets in-app tab badge on iOS
+  EventEmitter.sendEvent('notifications', {
+    notificationsBadgeCount: count,
   });
 };


### PR DESCRIPTION
Opening a PR for this since this changes some complex behavior and I want to get another set of eyes on it. 

This changes the behavior of the notifs screen so that the badge always clears when you navigate to the page. If the tab is already selected when a notif comes in or if you tap a push notif and it opens to your notif page, the badge doesn't clear until you navigate away from the tab.

This is accomplished by badge updating from marking notifs as read and handling each in the UI independently. 

What I tested on both iOS and Android:
- App open on home → notif comes in → notif tab badge count goes to one → tap notif tab → badge count clears
- App open on on notifs tab → push notif comes in → tab correctly shows a badge count of 1
- Tapping push notif → opens to notif tab and correctly shows a badge count of 1
- App closed → push notif comes in → app badge increments → tap app → in-app badge shows 1 → tap notif tab → badge count clears
